### PR TITLE
Compatibility module for Parsetree.pattern_desc.

### DIFF
--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -38,6 +38,37 @@ module Constant = struct
 
 end 
 
+module Pattern = struct
+  type 'a loc = 'a Asttypes.loc
+  type constant = Parsetree.constant
+
+  type t = Parsetree.pattern_desc =
+      Ppat_any
+    | Ppat_var of string loc
+    | Ppat_alias of pattern * string loc
+    | Ppat_constant of constant
+    | Ppat_interval of constant * constant
+    | Ppat_tuple of pattern list
+    | Ppat_construct of Longident.t loc * pattern option
+    | Ppat_variant of label * pattern option
+    | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+    | Ppat_array of pattern list
+    | Ppat_or of pattern * pattern
+    | Ppat_constraint of pattern * core_type
+    | Ppat_type of Longident.t loc
+    | Ppat_lazy of pattern
+    | Ppat_unpack of string loc
+    | Ppat_exception of pattern
+    | Ppat_extension of extension
+    | Ppat_open of Longident.t loc * pattern
+
+  let of_pattern_desc p = p
+  let to_pattern_desc p = p
+
+  let have_ppat_open = true
+  let open_ = Pat.open_
+end
+
 let may_tuple ?loc tup = function
   | [] -> None
   | [x] -> Some x

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -43,6 +43,46 @@ module Constant : sig
 
 end
 
+(** Abstracts the addition of Ppat_open in OCaml 4.04. *)
+module Pattern : sig
+  type 'a loc = 'a Asttypes.loc
+  type constant = Constant.t
+
+  type t =
+      Ppat_any
+    | Ppat_var of string loc
+    | Ppat_alias of pattern * string loc
+    | Ppat_constant of constant
+    | Ppat_interval of constant * constant
+    | Ppat_tuple of pattern list
+    | Ppat_construct of Longident.t loc * pattern option
+    | Ppat_variant of label * pattern option
+    | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+    | Ppat_array of pattern list
+    | Ppat_or of pattern * pattern
+    | Ppat_constraint of pattern * core_type
+    | Ppat_type of Longident.t loc
+    | Ppat_lazy of pattern
+    | Ppat_unpack of string loc
+    | Ppat_exception of pattern
+    | Ppat_extension of extension
+    | Ppat_open of Longident.t loc * pattern
+
+  val of_pattern_desc : Parsetree.pattern_desc -> t
+
+  (** Converts [Pattern.t] to [Parsetree.pattern_desc]. If the given value is
+      constructed with [Ppat_open] and the OCaml version is less than [4.04],
+      raises [Failure]. *)
+  val to_pattern_desc : t -> Parsetree.pattern_desc
+
+  (** [true] if and only if [Ppat_open] is available (OCaml >= [4.04]). *)
+  val have_ppat_open : bool
+
+  (** On OCaml >= [4.04], forwards to [Ast_helper.Pat.open_]. Otherwise, raises
+      [Failure]. *)
+  val open_ : ?loc:Ast_helper.loc -> ?attrs:attrs -> lid -> pattern -> pattern
+end
+
 (** {2 Misc} *)
 
 val lid: ?loc:loc -> string -> lid


### PR DESCRIPTION
OCaml 4.04 adds the `Ppat_open` constructor. This makes code that pattern matches on `pattern_desc` not portable between 4.04 and 4.03.

This is the 4.04 implementation of the compatibility module.

Closes #53.

See https://github.com/aantron/bisect_ppx/pull/113, https://github.com/aantron/bisect_ppx/issues/112
cc @rleonid, @gasche
