### PR TITLE
Compatibility module for Parsetree.pattern_desc (4.02, 4.03 version).

### DIFF
--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -38,6 +38,81 @@ module Constant = struct
 
 end 
 
+module Pattern = struct
+  type 'a loc = 'a Asttypes.loc
+  type constant = Constant.t
+
+  type t =
+      Ppat_any
+    | Ppat_var of string loc
+    | Ppat_alias of pattern * string loc
+    | Ppat_constant of constant
+    | Ppat_interval of constant * constant
+    | Ppat_tuple of pattern list
+    | Ppat_construct of Longident.t loc * pattern option
+    | Ppat_variant of label * pattern option
+    | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+    | Ppat_array of pattern list
+    | Ppat_or of pattern * pattern
+    | Ppat_constraint of pattern * core_type
+    | Ppat_type of Longident.t loc
+    | Ppat_lazy of pattern
+    | Ppat_unpack of string loc
+    | Ppat_exception of pattern
+    | Ppat_extension of extension
+    | Ppat_open of Longident.t loc * pattern
+
+  let of_pattern_desc = function
+    | Parsetree.Ppat_any -> (Ppat_any : t)
+    | Parsetree.Ppat_var s -> Ppat_var s
+    | Parsetree.Ppat_alias (p, s) -> Ppat_alias (p, s)
+    | Parsetree.Ppat_constant c -> Ppat_constant (Constant.of_constant c)
+    | Parsetree.Ppat_interval (c, c') ->
+      Ppat_interval (Constant.of_constant c, Constant.of_constant c')
+    | Parsetree.Ppat_tuple ps -> Ppat_tuple ps
+    | Parsetree.Ppat_construct (c, p) -> Ppat_construct (c, p)
+    | Parsetree.Ppat_variant (s, p) -> Ppat_variant (s, p)
+    | Parsetree.Ppat_record (fs, c) -> Ppat_record (fs, c)
+    | Parsetree.Ppat_array ps -> Ppat_array ps
+    | Parsetree.Ppat_or (p, p') -> Ppat_or (p, p')
+    | Parsetree.Ppat_constraint (p, t) -> Ppat_constraint (p, t)
+    | Parsetree.Ppat_type t -> Ppat_type t
+    | Parsetree.Ppat_lazy p -> Ppat_lazy p
+    | Parsetree.Ppat_unpack s -> Ppat_unpack s
+    | Parsetree.Ppat_exception p -> Ppat_exception p
+    | Parsetree.Ppat_extension e -> Ppat_extension e
+
+  let to_pattern_desc = function
+    | (Ppat_any : t) -> Parsetree.Ppat_any
+    | Ppat_var s -> Parsetree.Ppat_var s
+    | Ppat_alias (p, s) -> Parsetree.Ppat_alias (p, s)
+    | Ppat_constant c -> Parsetree.Ppat_constant (Constant.to_constant c)
+    | Ppat_interval (c, c') ->
+      Parsetree.Ppat_interval (Constant.to_constant c, Constant.to_constant c')
+    | Ppat_tuple ps -> Parsetree.Ppat_tuple ps
+    | Ppat_construct (c, p) -> Parsetree.Ppat_construct (c, p)
+    | Ppat_variant (s, p) -> Parsetree.Ppat_variant (s, p)
+    | Ppat_record (fs, c) -> Parsetree.Ppat_record (fs, c)
+    | Ppat_array ps -> Parsetree.Ppat_array ps
+    | Ppat_or (p, p') -> Parsetree.Ppat_or (p, p')
+    | Ppat_constraint (p, t) -> Parsetree.Ppat_constraint (p, t)
+    | Ppat_type t -> Parsetree.Ppat_type t
+    | Ppat_lazy p -> Parsetree.Ppat_lazy p
+    | Ppat_unpack s -> Parsetree.Ppat_unpack s
+    | Ppat_exception p -> Parsetree.Ppat_exception p
+    | Ppat_extension e -> Parsetree.Ppat_extension e
+    | Ppat_open _ ->
+      failwith
+        ("ppx_tools: Ast_convenience.Pattern.to_pattern_desc: " ^
+         "Ppat_open is not available in OCaml < 4.04")
+
+  let have_ppat_open = false
+  let open_ ?loc ?attrs _ _ =
+    failwith
+      ("ppx_tools: Ast_convenience.Pattern.open_: " ^
+       "Ppat_open is not available in OCaml < 4.04")
+end
+
 let may_tuple ?loc tup = function
   | [] -> None
   | [x] -> Some x

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -43,6 +43,46 @@ module Constant : sig
 
 end
 
+(** Abstracts the addition of Ppat_open in OCaml 4.04. *)
+module Pattern : sig
+  type 'a loc = 'a Asttypes.loc
+  type constant = Constant.t
+
+  type t =
+      Ppat_any
+    | Ppat_var of string loc
+    | Ppat_alias of pattern * string loc
+    | Ppat_constant of constant
+    | Ppat_interval of constant * constant
+    | Ppat_tuple of pattern list
+    | Ppat_construct of Longident.t loc * pattern option
+    | Ppat_variant of label * pattern option
+    | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+    | Ppat_array of pattern list
+    | Ppat_or of pattern * pattern
+    | Ppat_constraint of pattern * core_type
+    | Ppat_type of Longident.t loc
+    | Ppat_lazy of pattern
+    | Ppat_unpack of string loc
+    | Ppat_exception of pattern
+    | Ppat_extension of extension
+    | Ppat_open of Longident.t loc * pattern
+
+  val of_pattern_desc : Parsetree.pattern_desc -> t
+
+  (** Converts [Pattern.t] to [Parsetree.pattern_desc]. If the given value is
+      constructed with [Ppat_open] and the OCaml version is less than [4.04],
+      raises [Failure]. *)
+  val to_pattern_desc : t -> Parsetree.pattern_desc
+
+  (** [true] if and only if [Ppat_open] is available (OCaml >= [4.04]). *)
+  val have_ppat_open : bool
+
+  (** On OCaml >= [4.04], forwards to [Ast_helper.Pat.open_]. Otherwise, raises
+      [Failure]. *)
+  val open_ : ?loc:Ast_helper.loc -> ?attrs:attrs -> lid -> pattern -> pattern
+end
+
 (** {2 Misc} *)
 
 val lid: ?loc:loc -> string -> lid


### PR DESCRIPTION
4.02, 4.03 companion to #54. The commit should be cherry-picked onto `4.02` if merged.
