### PR TITLE
genlifter: fix code generation for inline records

### DIFF
--- a/genlifter.ml
+++ b/genlifter.ml
@@ -105,12 +105,8 @@ module Main : sig end = struct
             | Cstr_record (l) ->
                 let l = List.map field l in
                 let keep_head ((lid, pattern), _) =
-                  let name = match lid.txt with
-                    | Longident.Lident name -> name
-                    | Longident.Ldot (_, name) -> name
-                    | Longident.Lapply _ -> assert false
-                  in
-                  ({lid with txt = Longident.Lident name}, pattern)
+                  let txt = Longident.Lident (Longident.last lid.txt) in
+                  ({lid with txt}, pattern)
                 in
                 pconstr qc [Pat.record (List.map keep_head l) Closed],
                 selfcall "constr"


### PR DESCRIPTION
The main problem with inline records is that labels are prefixed with an absolute path, e.g.
```ocaml
  type t = A of { a : string; b : int }
```
generates code which looks like:
```ocaml
class virtual ['res] lifter =
  object (this)
    method lift_Test_t : Test.t -> 'res=
      (function
       | Test.A { Test.a = a; Test.b = b } ->
           this#constr "Test.t"
             ("A",
               (this#record "Test.t.A"
                  [("a", (this#string a)); ("b", (this#int b))])) : Test.t ->
                                                                    'res)
  end
```
which is not valid OCaml code.
For inline records, labels should just be identifiers (disambiguation is based on the name of the constructor, e.g. Test.A in this example).

This patch removes the prefix at two levels:
- qualified paths in the patterns of the lifter code
- qualified paths in the parsetree produced by the lifter

The bug was found by @daacaceressa who helped testing this solution.
Open question: should we backport the patch to older versions of OCaml? Because of this issue, inline records have never been supported by genlifter.