### PR TITLE
OCaml 4.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
    - PACKAGE="ppx_tools"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
  matrix:
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.10.0+rc2 OCAML_BETA=enable
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -53,7 +53,7 @@ let tuple ?loc ?attrs = function
   | xs -> Exp.tuple ?loc ?attrs xs
 let cons ?loc ?attrs hd tl = constr ?loc ?attrs "::" [hd; tl]
 let list ?loc ?attrs l = List.fold_right (cons ?loc ?attrs) l (nil ?loc ?attrs ())
-let str ?loc ?attrs s = Exp.constant ?loc ?attrs (Pconst_string (s, Location.none, None))
+let str ?(loc = !default_loc) ?attrs s = Exp.constant ~loc ?attrs (Pconst_string (s, loc, None))
 let int ?loc ?attrs x = Exp.constant ?loc ?attrs (Pconst_integer (string_of_int x, None))
 let int32 ?loc ?attrs x = Exp.constant ?loc ?attrs (Pconst_integer (Int32.to_string x, Some 'l'))
 let int64 ?loc ?attrs x = Exp.constant ?loc ?attrs (Pconst_integer (Int64.to_string x, Some 'L'))
@@ -85,7 +85,7 @@ let ptuple ?loc ?attrs = function
   | xs -> Pat.tuple ?loc ?attrs xs
 let plist ?loc ?attrs l = List.fold_right (pcons ?loc ?attrs) l (pnil ?loc ?attrs ())
 
-let pstr ?loc ?attrs s = Pat.constant ?loc ?attrs (Pconst_string (s, Location.none, None))
+let pstr ?(loc = !default_loc) ?attrs s = Pat.constant ~loc ?attrs (Pconst_string (s, loc, None))
 let pint ?loc ?attrs x = Pat.constant ?loc ?attrs (Pconst_integer (string_of_int x, None))
 let pchar ?loc ?attrs x = Pat.constant ?loc ?attrs (Pconst_char x)
 let pfloat ?loc ?attrs x = Pat.constant ?loc ?attrs (Pconst_float (string_of_float x, None))

--- a/ast_convenience.ml
+++ b/ast_convenience.ml
@@ -29,7 +29,7 @@ module Constant = struct
   type t = Parsetree.constant =
      Pconst_integer of string * char option
    | Pconst_char of char
-   | Pconst_string of string * string option
+   | Pconst_string of string * Location.t * string option
    | Pconst_float of string * char option
 
   let of_constant x = x
@@ -43,7 +43,7 @@ let may_tuple ?loc tup = function
   | [x] -> Some x
   | l -> Some (tup ?loc ?attrs:None l)
 
-let lid ?(loc = !default_loc) s = mkloc (Longident.parse s) loc
+let lid ?(loc = !default_loc) s = mkloc (Longident.parse s) loc [@ocaml.warning "-3"]
 let constr ?loc ?attrs s args = Exp.construct ?loc ?attrs (lid ?loc s) (may_tuple ?loc Exp.tuple args)
 let nil ?loc ?attrs () = constr ?loc ?attrs "[]" []
 let unit ?loc ?attrs () = constr ?loc ?attrs "()" []
@@ -53,7 +53,7 @@ let tuple ?loc ?attrs = function
   | xs -> Exp.tuple ?loc ?attrs xs
 let cons ?loc ?attrs hd tl = constr ?loc ?attrs "::" [hd; tl]
 let list ?loc ?attrs l = List.fold_right (cons ?loc ?attrs) l (nil ?loc ?attrs ())
-let str ?loc ?attrs s = Exp.constant ?loc ?attrs (Pconst_string (s, None))
+let str ?loc ?attrs s = Exp.constant ?loc ?attrs (Pconst_string (s, Location.none, None))
 let int ?loc ?attrs x = Exp.constant ?loc ?attrs (Pconst_integer (string_of_int x, None))
 let int32 ?loc ?attrs x = Exp.constant ?loc ?attrs (Pconst_integer (Int32.to_string x, Some 'l'))
 let int64 ?loc ?attrs x = Exp.constant ?loc ?attrs (Pconst_integer (Int64.to_string x, Some 'L'))
@@ -85,7 +85,7 @@ let ptuple ?loc ?attrs = function
   | xs -> Pat.tuple ?loc ?attrs xs
 let plist ?loc ?attrs l = List.fold_right (pcons ?loc ?attrs) l (pnil ?loc ?attrs ())
 
-let pstr ?loc ?attrs s = Pat.constant ?loc ?attrs (Pconst_string (s, None))
+let pstr ?loc ?attrs s = Pat.constant ?loc ?attrs (Pconst_string (s, Location.none, None))
 let pint ?loc ?attrs x = Pat.constant ?loc ?attrs (Pconst_integer (string_of_int x, None))
 let pchar ?loc ?attrs x = Pat.constant ?loc ?attrs (Pconst_char x)
 let pfloat ?loc ?attrs x = Pat.constant ?loc ?attrs (Pconst_float (string_of_float x, None))
@@ -93,11 +93,11 @@ let pfloat ?loc ?attrs x = Pat.constant ?loc ?attrs (Pconst_float (string_of_flo
 let tconstr ?loc ?attrs c l = Typ.constr ?loc ?attrs (lid ?loc c) l
 
 let get_str = function
-  | {pexp_desc=Pexp_constant (Pconst_string (s, _)); _} -> Some s
+  | {pexp_desc=Pexp_constant (Pconst_string (s, _, _)); _} -> Some s
   | _ -> None
 
 let get_str_with_quotation_delimiter = function
-  | {pexp_desc=Pexp_constant (Pconst_string (s, d)); _} -> Some (s, d)
+  | {pexp_desc=Pexp_constant (Pconst_string (s, _, d)); _} -> Some (s, d)
   | _ -> None
 
 let get_lid = function

--- a/ast_convenience.mli
+++ b/ast_convenience.mli
@@ -32,7 +32,7 @@ module Constant : sig
   type t = Parsetree.constant =
      Pconst_integer of string * char option 
    | Pconst_char of char 
-   | Pconst_string of string * string option 
+   | Pconst_string of string * Location.t * string option
    | Pconst_float of string * char option 
  
   (** Convert Asttypes.constant to Constant.t *) 

--- a/ast_mapper_class.ml
+++ b/ast_mapper_class.ml
@@ -603,6 +603,8 @@ class mapper =
       | PTyp x -> PTyp (this # typ x)
       | PPat (x, g) -> PPat (this # pat x, map_opt (this # expr) g)
       | PSig x -> PSig (this # signature x)
+
+    method constant (c : Parsetree.constant) = c
   end
 
 
@@ -623,6 +625,7 @@ let to_mapper this =
     class_type = (fun _ -> this # class_type);
     class_type_declaration = (fun _ -> this # class_type_declaration);
     class_type_field = (fun _ -> this # class_type_field);
+    constant = (fun _ -> this # constant);
     constructor_declaration = (fun _ -> this # constructor_declaration);
     expr = (fun _ -> this # expr);
     extension = (fun _ -> this # extension);

--- a/ast_mapper_class.ml
+++ b/ast_mapper_class.ml
@@ -604,7 +604,11 @@ class mapper =
       | PPat (x, g) -> PPat (this # pat x, map_opt (this # expr) g)
       | PSig x -> PSig (this # signature x)
 
-    method constant (c : Parsetree.constant) = c
+    method constant = function
+      | Pconst_integer (str, suffix) -> Pconst_integer (str, suffix)
+      | Pconst_char c -> Pconst_char c
+      | Pconst_string (str, loc, delim) -> Pconst_string (str, this # location loc, delim)
+      | Pconst_float (str, suffix) -> Pconst_float (str, suffix)
   end
 
 

--- a/ast_mapper_class.mli
+++ b/ast_mapper_class.mli
@@ -22,6 +22,7 @@ class mapper:
     method class_type: class_type -> class_type
     method class_type_declaration: class_type_declaration -> class_type_declaration
     method class_type_field: class_type_field -> class_type_field
+    method constant : constant -> constant
     method constructor_arguments: constructor_arguments -> constructor_arguments
     method constructor_declaration: constructor_declaration -> constructor_declaration
     method expr: expression -> expression

--- a/genlifter.ml
+++ b/genlifter.ml
@@ -48,7 +48,7 @@ module Main : sig end = struct
 
   let rec gen ty =
     if Hashtbl.mem printed ty then ()
-    else let tylid = Longident.parse ty in
+    else let tylid = Longident.parse ty [@ocaml.warning "-3"] in
       let td =
         try snd (Env.find_type_by_name tylid env)
         with Not_found ->

--- a/ppx_metaquot.ml
+++ b/ppx_metaquot.ml
@@ -69,7 +69,7 @@ end = struct
 
   let prefix ty s =
     let open Longident in
-    match parse ty with
+    match Longident.parse ty [@ocaml.warning "-3"] with
     | Ldot(m, _) -> String.concat "." (Longident.flatten m) ^ "." ^ s
     | _ -> s
 


### PR DESCRIPTION
Port work from @rwmjones. See https://github.com/ocaml-ppx/ppx_tools/issues/81

Here two points I'm not so sure about:
* I'm not sure what is the constant method. The original commit had a `(* XXX? *)` comment there.
* I'm not sure what to use instead of the deprecated `Longident.parse x` as the proposed `Parse.longident (Lexing.from_string x)` does not work and fails to parse several things. @octachron any idea?